### PR TITLE
Updated Linux installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Check out this video.
 
 ## Linux Installation
  - Install [Python3](https://www.python.org/downloads/)
+ - Install python3-pip
  - Download or clone this repo.
  - Unzip and put in directory
  - Install Dependencies

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Check out this video.
 ## Linux Installation
  - Install [Python3](https://www.python.org/downloads/)
  - Install python3-pip
+        `apt install -y python3-pip`
  - Download or clone this repo.
  - Unzip and put in directory
  - Install Dependencies


### PR DESCRIPTION
added python3-pip to the installation instructions because it doesn't ship with every distribution by default.